### PR TITLE
Adds test for 'end' method.

### DIFF
--- a/lib/client-api.js
+++ b/lib/client-api.js
@@ -41,7 +41,7 @@ module.exports = function defineClientTests(Client, Adapter, timeout) {
 
       describe('client.end(cb)', function() {
         it('End the connection.', function (done) {
-          this.client.end(this.topic, done);
+          this.client.end(done);
         });
       });
     });

--- a/lib/client-api.js
+++ b/lib/client-api.js
@@ -23,19 +23,25 @@ module.exports = function defineClientTests(Client, Adapter, timeout) {
         });
       });
 
-      describe('client.subscribe(topic, options, cb', function() {
+      describe('client.subscribe(topic, options, cb)', function() {
         it('Subscribe to the specified `topic` or **topic pattern**.', function (done) {
           this.client.subscribe(this.topic, done);
         });
       });
 
-      describe('client.unsubscribe(topic, options, cb', function() {
+      describe('client.unsubscribe(topic, options, cb)', function() {
         it('Unsubscribe from the specified `topic` or **topic pattern**.', function (done) {
           var test = this;
           this.client.subscribe(this.topic, function(err) {
             if(err) return done(err);
             test.client.unsubscribe(test.topic, done);
           });
+        });
+      });
+
+      describe('client.end(cb)', function() {
+        it('End the connection.', function (done) {
+          this.client.end(this.topic, done);
         });
       });
     });


### PR DESCRIPTION
This method is broken in strong-pubsub-redis, and the test coverage didn't catch it. Fixed that bug, and added a test case for it here.
